### PR TITLE
Fix issue where cards.css is renamed to cards.PNG

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,9 +144,6 @@ gulp.task("generate sprites", ["resize lg"], function() {
     //template: "./client/scss/_cards.hbs"
   })
   .pipe(imagemin())
-  .pipe(gulpif("*.png", rename({
-    extname: ".PNG"
-  })))
   .pipe(gulp.dest("./public/build/"));
 })
 


### PR DESCRIPTION
I'm not quite sure why `gulpif( ... )` isn't working. In any case, it's renaming `cards.css` to `cards.PNG`, causing the card sprites to not display in the web app. I wish I knew a better way to fix this, besides removing these few lines.