### PR TITLE
Fix #6: images not being loaded

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,7 +144,9 @@ gulp.task("generate sprites", ["resize lg"], function() {
     //template: "./client/scss/_cards.hbs"
   })
   .pipe(imagemin())
-  .pipe(gulpif("*.png", rename({
+  .pipe(gulpif(function (file) {
+    return file.path.match(".*\\.png$") != null;
+  }, rename({
     extname: ".PNG"
   })))
   .pipe(gulp.dest("./public/build/"));


### PR DESCRIPTION
The `gulpif` condition has been changed according to the documentation to be a function taking **Vinyl** object.

The `generate_sprites` task would generate `cards.css` file and rename it to `cards.PNG` due to wrong `gulpif` condition.

The fix was suggested in #6 and the code change was inspired by #12 (I've decided to keep the renaming as intended by the author).